### PR TITLE
듣보잡

### DIFF
--- a/BKJ/듣보잡/Komo1284.py
+++ b/BKJ/듣보잡/Komo1284.py
@@ -1,0 +1,16 @@
+n, m = map(int, input().split())
+
+N = set()  # 리스트 대신 set 사용
+M = set()  # 리스트 대신 set 사용
+
+for _ in range(n):
+    N.add(input())
+
+for _ in range(m):
+    M.add(input())
+
+result = sorted(N & M)  # 교집합 후 정렬
+
+print(len(result))
+for name in result:
+    print(name)


### PR DESCRIPTION
## 📌 문제 번호
#28 

## 📝 배운 개념 
리스트에서 in 연산자를 사용할 때, 파이썬은 리스트의 처음부터 끝까지 순차적으로 검색을 수행함. 
이는 리스트의 크기가 커질수록 검색 시간이 선형적으로 증가한다는 것을 의미

-> 
** 자료구조 변경** : list 대신 set 사용

set은 해시 테이블을 기반으로 구현되어 있어 검색 연산의 시간 복잡도가 O(1)
중복된 원소를 자동으로 제거해주는 특성도 있음

**검색 방식 개선** : in 연산자 대신 집합 연산자 사용

& 연산자를 사용하여 두 집합의 교집합을 구함
이는 개별 검색보다 훨씬 효율적